### PR TITLE
Add Crossblooded Sorcerer support (fixes #10 for them)

### DIFF
--- a/SpellbookMerge/Features/IncorporateSpellbook.cs
+++ b/SpellbookMerge/Features/IncorporateSpellbook.cs
@@ -49,6 +49,7 @@ namespace SpellbookMerge.Features
                     Resources.SpellbookBlueprints.EldritchScionSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
                 };
                 bp.m_MythicSpellList = Resources.SpellListBlueprints.AzataSpellList.ToReference<BlueprintSpellListReference>();
                 bp.IsClassFeature = true;
@@ -72,6 +73,7 @@ namespace SpellbookMerge.Features
                     Resources.SpellbookBlueprints.EldritchScionSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
                 };
                 bp.m_MythicSpellList = Resources.SpellListBlueprints.DemonSpellList.ToReference<BlueprintSpellListReference>();
                 bp.IsClassFeature = true;

--- a/SpellbookMerge/Resources.cs
+++ b/SpellbookMerge/Resources.cs
@@ -38,6 +38,7 @@ namespace SpellbookMerge
             public static BlueprintSpellbook EldritchScionSpellbook => TryGetBlueprint<BlueprintSpellbook>("e2763fbfdb91920458c4686c3e7ed085")!;
             public static BlueprintSpellbook ArcanistSpellbook => TryGetBlueprint<BlueprintSpellbook>("33903fe5c4abeaa45bc249adb9d98848")!;
             public static BlueprintSpellbook SageSpellbook => TryGetBlueprint<BlueprintSpellbook>("cc2052732997b654e93eac268a39a0a9")!;
+            public static BlueprintSpellbook CrossbloodedSpellbook => TryGetBlueprint<BlueprintSpellbook>("cb0be5988031ebe4c947086a1170eacc")!;
         }
 
         internal static class SpellListBlueprints


### PR DESCRIPTION
The Crossblooded sorcerer archetype has a separate spellbook from the base class; this adds the spellbook to the mythic paths currently merged. I've checked that, on gaining Mythic Rank 3, Azata and Demon both seem to allow selection, have not tested progression further than that though.