### PR TITLE
EE Release with lots of new spellbooks

### DIFF
--- a/SpellbookMerge/Features/IncorporateSpellbook.cs
+++ b/SpellbookMerge/Features/IncorporateSpellbook.cs
@@ -21,6 +21,17 @@ namespace SpellbookMerge.Features
                     Resources.SpellbookBlueprints.SwordSaintSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.HunterSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.EldritchScionSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WizardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.OracleSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.BardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ShamanSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ClericSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WitchSpellbook.ToReference<BlueprintSpellbookReference>(),
+
                 };
                 bp.m_MythicSpellList = Resources.SpellListBlueprints.AeonSpellList.ToReference<BlueprintSpellListReference>();
                 // TODO This is just there for compatibility with Owlcat new changes in 1.3. We are not using it yet, since we reverted to the old merging behavior
@@ -53,6 +64,10 @@ namespace SpellbookMerge.Features
                     Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.OracleSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ShamanSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ClericSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WitchSpellbook.ToReference<BlueprintSpellbookReference>(),
                 };
                 bp.m_MythicSpellList = Resources.SpellListBlueprints.AzataSpellList.ToReference<BlueprintSpellListReference>();
                 // TODO This is just there for compatibility with Owlcat new changes in 1.3. We are not using it yet, since we reverted to the old merging behavior
@@ -80,6 +95,15 @@ namespace SpellbookMerge.Features
                     Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.OracleSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.BardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ShamanSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ClericSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WizardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.DruidSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WitchSpellbook.ToReference<BlueprintSpellbookReference>(),
                 };
                 bp.m_MythicSpellList = Resources.SpellListBlueprints.DemonSpellList.ToReference<BlueprintSpellListReference>();
                 // TODO This is just there for compatibility with Owlcat new changes in 1.3. We are not using it yet, since we reverted to the old merging behavior
@@ -106,6 +130,16 @@ namespace SpellbookMerge.Features
                     Resources.SpellbookBlueprints.SkaldSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.WitchSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.EldritchScionSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.OracleSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ShamanSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ClericSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WizardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.DruidSpellbook.ToReference<BlueprintSpellbookReference>(),
                 };
                 bp.m_MythicSpellList = Resources.SpellListBlueprints.TricksterSpellList.ToReference<BlueprintSpellListReference>();
                 // TODO This is just there for compatibility with Owlcat new changes in 1.3. We are not using it yet, since we reverted to the old merging behavior

--- a/SpellbookMerge/Info.json
+++ b/SpellbookMerge/Info.json
@@ -2,7 +2,7 @@
   "Id": "SpellbookMerge",
   "DisplayName": "Spellbook Merge",
   "Author": "vikigenius",
-  "Version": "1.6.0",
+  "Version": "1.7.0",
   "ManagerVersion": "0.21.3",
   "Requirements": [],
   "AssemblyName": "SpellbookMerge.dll",

--- a/SpellbookMerge/Patches/MythicProgression.cs
+++ b/SpellbookMerge/Patches/MythicProgression.cs
@@ -23,21 +23,47 @@ namespace SpellbookMerge.Patches
                 PatchDemonProgression();
                 PatchTricksterProgression();
                 PatchAngelAllowedMerges();
+                PatchLichAllowedMerges();
             }
 
             private static void PatchAngelAllowedMerges()
             {
                 var angelIncorporateSpellbookFeature = Resources.MythicMergeBlueprints.AngelIncorporateSpellbook;
                 var angelAllowedMerges = new List<BlueprintSpellbookReference>(angelIncorporateSpellbookFeature.m_AllowedSpellbooks);
-                var additionalMerges = new List<BlueprintSpellbookReference> 
+                var additionalMerges = new List<BlueprintSpellbookReference>
                 {
-                    Resources.SpellbookBlueprints.PaladinSpellbook.ToReference<BlueprintSpellbookReference>()
+                    Resources.SpellbookBlueprints.PaladinSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WarPriestSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WizardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.WitchSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.SageSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.CrossbloodedSpellbook.ToReference<BlueprintSpellbookReference>(),
                 };
                 angelAllowedMerges.AddRange(additionalMerges);
                 angelIncorporateSpellbookFeature.m_AllowedSpellbooks = angelAllowedMerges.ToArray();
                 Main.Log("Patched Angel allowed spellbook merges");
             }
-            
+
+            private static void PatchLichAllowedMerges()
+            {
+                var lichIncorporateSpellbookFeature = Resources.MythicMergeBlueprints.LichIncorporateSpellbook;
+                var lichAllowedMerges = new List<BlueprintSpellbookReference>(lichIncorporateSpellbookFeature.m_AllowedSpellbooks);
+                var additionalMerges = new List<BlueprintSpellbookReference>
+                {
+                    Resources.SpellbookBlueprints.DruidSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.OracleSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.BardSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ShamanSpellbook.ToReference<BlueprintSpellbookReference>(),
+                    Resources.SpellbookBlueprints.ClericSpellbook.ToReference<BlueprintSpellbookReference>(),
+
+                };
+                lichAllowedMerges.AddRange(additionalMerges);
+                lichIncorporateSpellbookFeature.m_AllowedSpellbooks = lichAllowedMerges.ToArray();
+                Main.Log("Patched Lich allowed spellbook merges");
+            }
+
             private static void PatchAeonProgression()
             {
                 var aeonProgression = Resources.ProgressionBlueprints.AeonProgression;

--- a/SpellbookMerge/Patches/MythicProgression.cs
+++ b/SpellbookMerge/Patches/MythicProgression.cs
@@ -33,7 +33,6 @@ namespace SpellbookMerge.Patches
                 var additionalMerges = new List<BlueprintSpellbookReference>
                 {
                     Resources.SpellbookBlueprints.PaladinSpellbook.ToReference<BlueprintSpellbookReference>(),
-                    Resources.SpellbookBlueprints.WarPriestSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.SorcererSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.WizardSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.ArcanistSpellbook.ToReference<BlueprintSpellbookReference>(),
@@ -54,7 +53,6 @@ namespace SpellbookMerge.Patches
                 {
                     Resources.SpellbookBlueprints.DruidSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.OracleSpellbook.ToReference<BlueprintSpellbookReference>(),
-                    Resources.SpellbookBlueprints.BardSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.ShamanSpellbook.ToReference<BlueprintSpellbookReference>(),
                     Resources.SpellbookBlueprints.ClericSpellbook.ToReference<BlueprintSpellbookReference>(),
 

--- a/SpellbookMerge/Resources.cs
+++ b/SpellbookMerge/Resources.cs
@@ -39,6 +39,10 @@ namespace SpellbookMerge
             public static BlueprintSpellbook ArcanistSpellbook => TryGetBlueprint<BlueprintSpellbook>("33903fe5c4abeaa45bc249adb9d98848")!;
             public static BlueprintSpellbook SageSpellbook => TryGetBlueprint<BlueprintSpellbook>("cc2052732997b654e93eac268a39a0a9")!;
             public static BlueprintSpellbook CrossbloodedSpellbook => TryGetBlueprint<BlueprintSpellbook>("cb0be5988031ebe4c947086a1170eacc")!;
+            public static BlueprintSpellbook OracleSpellbook => TryGetBlueprint<BlueprintSpellbook>("6c03364712b415941a98f74522a81273")!;
+            public static BlueprintSpellbook ClericSpellbook => TryGetBlueprint<BlueprintSpellbook>("4673d19a0cf2fab4f885cc4d1353da33")!;
+            public static BlueprintSpellbook ShamanSpellbook => TryGetBlueprint<BlueprintSpellbook>("44f16931dabdff643bfe2a48138e769f")!;
+
         }
 
         internal static class SpellListBlueprints


### PR DESCRIPTION
This release aims to add all full caster spellbooks to every mythic path with spellbook merge enabled, along with a few other spellbook combos, including:

- General compatibility for Divine classes for Lich
- Bard for Demon and Lich
- Warpriest for Angel